### PR TITLE
Add Timeline component styles

### DIFF
--- a/scripts/sass.js
+++ b/scripts/sass.js
@@ -1,26 +1,44 @@
 const fs = require('fs')
-const mkdirp = require('mkdirp')
+const glob = require('glob')
 const harvester = require('seed-harvester')
+const mkdirp = require('mkdirp')
+const path= require('path')
 const sass = require('node-sass')
 
 const includePaths = harvester([
   './src/scss'
 ])
 
-mkdirp('./dist')
-mkdirp('./dist/css')
-mkdirp('./dist/scss')
+mkdirp.sync('./dist/css')
+mkdirp.sync('./dist/scss')
 
 const files = [
-  'styles.web',
-  'styles.android',
-  'styles.ios',
+  'src/scss/styles.*.scss',
+  'src/scss/components/*/styles.scss',
 ]
 
+const parseFileName = (fileName) => {
+  return fileName
+    .replace('src/scss/', '')
+    .replace('src/scss', '')
+    .replace('.scss', '')
+}
+
+const createDir = (fileName) => {
+  const dirName = path.dirname(fileName)
+    .replace('src/scss/', '')
+    .replace('src/scss', '')
+  if (dirName.length && dirName.length > 1) {
+    mkdirp.sync(`./dist/scss/${dirName}`)
+    mkdirp.sync(`./dist/css/${dirName}`)
+  }
+}
+
 const renderFile = (fileName) => {
+  const baseFileName = parseFileName(fileName)
   // Default .css compile
   return sass.render({
-    file: `./src/scss/${fileName}.scss`,
+    file: fileName,
     includePaths: includePaths,
     outputStyle: 'compact'
   }, function (error, result) {
@@ -28,23 +46,27 @@ const renderFile = (fileName) => {
       console.error(error)
       return process.exit(1)
     } else {
-      fs.writeFile(`./dist/css/${fileName}.css`, result.css, function (err) {
+      createDir(fileName)
+      fs.writeFile(`./dist/css/${baseFileName}.css`, result.css, function (err) {
         if (err) {
           console.error(error)
           return process.exit(1)
         }
-        console.log(`${fileName}.css created.`)
+        console.log(`${baseFileName}.css created.`)
 
-        fs.writeFile(`./dist/scss/${fileName}.scss`, result.css, function (err) {
+        fs.writeFile(`./dist/scss/${baseFileName}.scss`, result.css, function (err) {
           if (err) {
             console.error(error)
             return process.exit(1)
           }
-          console.log(`${fileName}.scss created.`)
+          // console.log(`${baseFileName}.scss created.`)
         })
       })
     }
   })
 }
 
-files.forEach(file => renderFile(file))
+
+files.forEach(file => glob.sync(file)
+  .filter(fileName => fileName)
+  .forEach(renderFile))

--- a/src/scss/base/wrapper/_article-container.scss
+++ b/src/scss/base/wrapper/_article-container.scss
@@ -15,6 +15,7 @@
   max-height: 600px;
   max-width: 406px;
   min-height: 480px;
+  min-width: 300px;
   overflow-x: hidden;
   overflow-y: auto;
   padding: 8px;

--- a/src/scss/components/BeaconHistoryTimeline/BeaconHistoryTimeline.scss
+++ b/src/scss/components/BeaconHistoryTimeline/BeaconHistoryTimeline.scss
@@ -1,0 +1,5 @@
+.c-BeaconHistoryTimeline {
+  @import "../../resets/base";
+  max-width: 800px;
+  width: 100%;
+}

--- a/src/scss/components/BeaconHistoryTimeline/BeaconHistoryTimelineHeading.scss
+++ b/src/scss/components/BeaconHistoryTimeline/BeaconHistoryTimelineHeading.scss
@@ -1,0 +1,9 @@
+@import "../../configs/color";
+
+.c-BeaconHistoryTimelineHeading {
+  @import "../../resets/base";
+  font-size: 15px;
+  font-weight: bold;
+  line-height: 1.1;
+  margin-bottom: 12px;
+}

--- a/src/scss/components/BeaconHistoryTimeline/BeaconHistoryTimelineList.scss
+++ b/src/scss/components/BeaconHistoryTimeline/BeaconHistoryTimelineList.scss
@@ -1,0 +1,4 @@
+.c-BeaconHistoryTimelineList {
+  @import "../../resets/base";
+  width: 100%;
+}

--- a/src/scss/components/BeaconHistoryTimeline/BeaconHistoryTimelineListItem.scss
+++ b/src/scss/components/BeaconHistoryTimeline/BeaconHistoryTimelineListItem.scss
@@ -1,0 +1,96 @@
+@import "../../configs/color";
+
+// Global variable
+$BeaconHistoryTimelineLinkColor: #1B79B5 !default;
+$BeaconHistoryTimelineLinkColor-hover: lighten($BeaconHistoryTimelineLinkColor, 8) !default;
+
+.c-BeaconHistoryTimelineListItem {
+  @import "../../resets/base";
+  // Variables
+  $item-padding: 6px;
+  $border-offset: 4px;
+  $border-width: 2px;
+  $dot-total-size: 10px;
+  $dot-border-width: $border-width;
+  $dot-size: $dot-total-size - ceil($dot-border-width * 2);
+  $dot-offset: $item-padding + ceil($dot-total-size / 2);
+  $timestamp-size: 60px;
+
+  color: _color(text);
+  display: block;
+  line-height: 1.5;
+  margin-left: $border-offset;
+  padding: $item-padding 0 $item-padding 20px;
+  position: relative;
+
+  &__block {
+    max-width: calc(100% - #{$timestamp-size});
+  }
+
+  &__timestamp {
+    min-width: $timestamp-size;
+  }
+
+  // Border
+  &::before {
+    background-color: _color(grey, 400);
+    bottom: 0;
+    content: "";
+    left: $border-offset;
+    position: absolute;
+    top: 0;
+    width: $border-width;
+    z-index: 0;
+  }
+
+  // Dot
+  &::after {
+    background-color: white;
+    border-radius: 50%;
+    border: $dot-border-width solid _color(grey, 800);
+    content: "";
+    display: block;
+    height: $dot-size;
+    left: 0;
+    position: absolute;
+    top: $dot-offset;
+    width: $dot-size;
+    z-index: 1;
+  }
+
+  &:first-child {
+    // Border
+    &::before {
+      bottom: 0;
+      top: $dot-offset;
+    }
+  }
+
+  &:last-child {
+    // Border
+    &::before {
+      bottom: calc(100% - (#{$dot-offset} + (#{$dot-size}/2)));
+      top: 0;
+    }
+  }
+
+  &:only-child {
+    // Border
+    &::before {
+      display: none;
+    }
+  }
+
+  // Link
+  a {
+    color: $BeaconHistoryTimelineLinkColor;
+    cursor: pointer;
+    outline: none;
+    text-decoration: none;
+
+    &:hover {
+      color: $BeaconHistoryTimelineLinkColor-hover;
+      text-decoration: underline;
+    }
+  }
+}

--- a/src/scss/components/BeaconHistoryTimeline/__index.scss
+++ b/src/scss/components/BeaconHistoryTimeline/__index.scss
@@ -1,0 +1,4 @@
+@import "./BeaconHistoryTimeline";
+@import "./BeaconHistoryTimelineHeading";
+@import "./BeaconHistoryTimelineList";
+@import "./BeaconHistoryTimelineListItem";

--- a/src/scss/components/BeaconHistoryTimeline/styles.scss
+++ b/src/scss/components/BeaconHistoryTimeline/styles.scss
@@ -1,0 +1,1 @@
+@import "./_index";

--- a/src/scss/components/__index.scss
+++ b/src/scss/components/__index.scss
@@ -1,0 +1,1 @@
+@import "./BeaconHistoryTimeline/_index";

--- a/src/scss/configs/_color.scss
+++ b/src/scss/configs/_color.scss
@@ -1,0 +1,13 @@
+@import "pack/seed-color-scheme/_index";
+
+// Text
+@include _color((
+  text: (
+    default: _color(charcoal, 700),
+    body: _color(charcoal, 400),
+    heading: _color(charcoal, 700),
+    subtle: _color(charcoal, 500),
+    muted: _color(charcoal, 300),
+    faint: _color(charcoal, 200),
+  )
+));

--- a/src/timeline.html
+++ b/src/timeline.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html>
+  <head>
+    <link rel="stylesheet" href="/css/main.css" />
+  </head>
+  <body>
+    <div class="c-article-container">
+      <div class="c-BeaconHistoryTimeline">
+        <div class="c-BeaconHistoryTimelineHeading" role="heading">
+          Beacon History
+        </div>
+        <div class="c-BeaconHistoryTimelineList" role="list">
+          <div class="c-BeaconHistoryTimelineListItem" role="list-item">
+            Beacon <a>J&G Marketing</a> opened
+          </div>
+          <div class="c-BeaconHistoryTimelineListItem" role="list-item">
+            Viewed <a>Plans & Pricing</a>
+          </div>
+          <div class="c-BeaconHistoryTimelineListItem" role="list-item">
+            Viewed <a>Team Settings</a>
+          </div>
+          <div class="c-BeaconHistoryTimelineListItem" role="list-item">
+            Searched for "How to recover deleted team"
+          </div>
+          <div class="c-BeaconHistoryTimelineListItem" role="list-item">
+            A really really long item. Searched for "How to recover deleted team"
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Add Timeline component styles

![screen shot 2017-12-13 at 1 48 45 pm](https://user-images.githubusercontent.com/2322354/33956545-d7843110-e00c-11e7-854d-d4d042af1237.jpg)

This update adds a new Timeline component shared styles. The Timeline styles
have been added to the base styles. However, a dedicated stylesheet file
is provided as well.

Markup has also been provided with the example timeline.html file.
The markup is build purely with `div` elements, to reduce the risk of expected
CSS overrides (at much as possible). In order to maintain accessibility,
`role` were provided to the applicable selectors.

The `sass.js` build file has been updated with a glob convention, to make it
easier to define target files.