### PR TITLE
Updated font and reduced padding

### DIFF
--- a/src/scss/base/_blockquote.scss
+++ b/src/scss/base/_blockquote.scss
@@ -4,6 +4,6 @@ blockquote {
   border-left: 2px solid _color(grey, 400);
   font-size: 1em;
   font-style: italic;
-  margin: 1.5em 1.2em;
-  padding: 0 0 0 1.5em;
+  margin: 1.5em 1.2em 1.5em 0;
+  padding: 0 0 0 1em;
 }

--- a/src/scss/base/_code.scss
+++ b/src/scss/base/_code.scss
@@ -6,7 +6,7 @@ pre {
   border-radius: 3px;
   color: _color(charcoal, 400);
   font-family: $font-family-serif;
-  font-size: 1em;
+  font-size: .9em;
   margin: 0 0 2em;
   overflow: auto;
   padding: 1.3em 1em;

--- a/src/scss/base/_list.scss
+++ b/src/scss/base/_list.scss
@@ -18,11 +18,11 @@ dl {
     display: inline-block;
     float: left;
     font-size: 1em;
-		font-weight:500;
+    font-weight:500;
     margin: 3px 0 0 0;
-		padding:0 .5em;
-		color:_color(charcoal, 600);
-		border-left:3px solid _color(blue, 500);
+    padding:0 .5em;
+    color:_color(charcoal, 600);
+    border-left:3px solid _color(blue, 500);
   }
 
   dd {

--- a/src/scss/base/_list.scss
+++ b/src/scss/base/_list.scss
@@ -14,23 +14,19 @@ dl {
   margin: 0 0 1em;
 
   dt {
-    background: _color(blue, 500);
-    border-radius: 50px;
-    color: _color(white);
+    color: inherit;
     display: inline-block;
     float: left;
-    font-size: 0.9em;
-    height: 30px;
-    line-height: 28px;
-    margin: 0;
-    text-align: center;
-    vertical-align: baseline;
-    white-space: nowrap;
-    width: 30px;
+    font-size: 1em;
+		font-weight:500;
+    margin: 3px 0 0 0;
+		padding:0 .5em;
+		color:_color(charcoal, 600);
+		border-left:3px solid _color(blue, 500);
   }
 
   dd {
     padding-top: 3px;
-    margin: 0 0 1.5em 3em;
+    margin: 0 0 1.5em 2em;
   }
 }

--- a/src/scss/base/_table.scss
+++ b/src/scss/base/_table.scss
@@ -12,7 +12,7 @@ table {
 
     th {
       display: table-cell;
-      padding: 0.5em;
+      padding: 0.5em 0;
       text-align: left;
       vertical-align: bottom;
 
@@ -24,7 +24,7 @@ table {
 
   td {
     border-top: 1px solid _color(grey, 400);
-    padding: 0.5em;
+    padding: 0.5em 0;
     text-align: left;
     vertical-align: top;
   }
@@ -45,6 +45,16 @@ table {
     border-radius: 3px;
     border: 1px solid _color(grey, 400);
     border-left: 0;
+		
+		td {
+			padding: 0.5em;
+		}
+		
+		thead {
+			th {
+				padding: 0.5em;
+			}
+		}
 
     tr {
       &:first-child {

--- a/src/scss/base/_table.scss
+++ b/src/scss/base/_table.scss
@@ -1,4 +1,3 @@
-
 @import "pack/seed-color-scheme/_index";
 
 table {
@@ -45,16 +44,16 @@ table {
     border-radius: 3px;
     border: 1px solid _color(grey, 400);
     border-left: 0;
-		
-		td {
-			padding: 0.5em;
-		}
-		
-		thead {
-			th {
-				padding: 0.5em;
-			}
-		}
+
+    td {
+      padding: 0.5em;
+    }
+
+    thead {
+      th {
+        padding: 0.5em;
+      }
+    }
 
     tr {
       &:first-child {

--- a/src/scss/configs/_font.scss
+++ b/src/scss/configs/_font.scss
@@ -1,2 +1,5 @@
-$font-family: "Aktiv Grotesk", "Helvetica Neue", Helvetica, Arial, sans-serif;
+@import url('https://fonts.googleapis.com/css?family=Roboto+Mono');
+@import url('https://fonts.googleapis.com/css?family=Roboto:300,400,500,700');
+
+$font-family: 'Roboto', 'Helvetica', sans-serif;
 $font-family-serif: 'Roboto Mono', Consolas, "Andale Mono", "Lucida Console", Monaco, "Courier New", Courier, monospace;

--- a/src/scss/mixins/_callout-styles.scss
+++ b/src/scss/mixins/_callout-styles.scss
@@ -2,13 +2,13 @@
 
 @mixin callout-styles($background, $border, $color, $dashed-color) {
   $callout-brdr: 2px;
-  $callout-copy-margin: 0 0 0.55em;
+  $callout-copy-margin: 0 0 0.3em;
   $callout-margin: 0 0 2em;
-  $callout-padding: 1em 1.5em;
+  $callout-padding: 1.2em 1em 1em;
   $callout-weight: 400;
 
   background: $background;
-  border-left: 5px solid $border;
+  border-left: 3px solid $border;
   border-radius: $callout-brdr;
   margin: $callout-margin;
   padding: $callout-padding;


### PR DESCRIPTION
## Updated font and reduced padding

![screen recording 2018-02-05 at 01 57 pm](https://user-images.githubusercontent.com/2322354/35823150-8710093a-0a7c-11e8-9a52-77951c6c89e2.gif)

Moved to Roboto for everything, and reduced as much horizontal padding
as possible to make the most of Beacon width. The most noticeable
change is in the definition list, which no longer has the garish blue
circle titles #sorrynotsorry