### PR TITLE
Heading: Add top margin

### DIFF
--- a/src/scss/base/_heading.scss
+++ b/src/scss/base/_heading.scss
@@ -4,6 +4,11 @@ h1, h2, h3, h4, h5, h6 {
   color: _color(charcoal, 600);
   font-weight: 500;
   margin-bottom: .65em;
+  margin-top: 1.26em;
+
+  &:first-child {
+    margin-top: 0;
+  }
 }
 
 h1 {


### PR DESCRIPTION
## Heading: Add top margin

![screen shot 2018-02-05 at 4 59 28 pm](https://user-images.githubusercontent.com/2322354/35831012-397e7bba-0a96-11e8-9bfc-01eb656fb6cb.jpg)


This update adds top margin to h1-h6 selectors. However, the top
margin is normalized to 0 if the node is the first child.