### PR TITLE
Prevent text resizing for iOS orientation change

### DIFF
--- a/src/scss/components/ios/_article.scss
+++ b/src/scss/components/ios/_article.scss
@@ -1,5 +1,9 @@
 // iOS :: Article
 
+html {
+    -webkit-text-size-adjust: none;
+}
+
 #fullArticle {
   padding: 0 15px;
 }


### PR DESCRIPTION
I uncovered this issue when fixing https://github.com/helpscout/beacon-ios-sdk/pull/77. The text would grow/shrink when the device orientation changed, but it should remain the same height. 

I found the solution in [this StackOverflow answer](https://stackoverflow.com/a/16471193/869).