### PR TITLE
Firefox: pre Rendering fix

### DIFF
--- a/src/scss/base/_code.scss
+++ b/src/scss/base/_code.scss
@@ -6,8 +6,15 @@ pre {
   border-radius: 3px;
   color: _color(charcoal, 400);
   font-family: $font-family-serif;
-  font-size: .9em;
+  font-size: 0.9em;
   margin: 0 0 2em;
   overflow: auto;
   padding: 1.3em 1em;
+
+  // Disable border-radius for Firefox.
+  // For some unknown reasons, pre + border-radius styles cause severe
+  // rendering issues with Firefox.
+  @-moz-document url-prefix() {
+    border-radius: initial;
+  }
 }


### PR DESCRIPTION
## Firefox: pre Rendering fix

![screen recording 2018-12-04 at 08 48 am](https://user-images.githubusercontent.com/2322354/49446297-dfb86880-f7a1-11e8-86c3-0663c8b66da0.gif)
(GIF shows rendering wonkiness with border-radius turned on)

This update fixes the `pre` tag rendering issues in Firefox.
The solution was to remove (or rather reset) the `border-radius`
styles, but only in FF within the stylesheet.

Absolutely no idea why this happens. This seems to resolve the
issue.