### PR TITLE
Add styles for nested <ol> tags

### DIFF
--- a/src/scss/base/_list.scss
+++ b/src/scss/base/_list.scss
@@ -1,8 +1,8 @@
 @import "pack/seed-color-scheme/_index";
 
 ul, ol {
-  list-style-position: inside;
-  padding-left: 0;
+  list-style-position: outside;
+  padding-left: 1em;
 }
 
 ol {

--- a/src/scss/base/_list.scss
+++ b/src/scss/base/_list.scss
@@ -5,6 +5,13 @@ ul, ol {
   padding-left: 0;
 }
 
+ol {
+  ol {
+    list-style-type: lower-alpha;
+    margin: 0 0 9px 25px;
+  }
+}
+
 li {
   margin-bottom: 0.2em;
 }


### PR DESCRIPTION
We had a customer report [this issue](https://github.com/helpscout/beacon-ios-sdk/issues/30) against the iOS SDK, but it looks like all Beacon clients need this css to match the behavior of docs web. 

I'm not sure about the margins if someone from design could weigh in on those. Below is a screenshot of these changes applied to iOS.

![Screen Shot 2019-04-01 at 12 26 19 PM](https://user-images.githubusercontent.com/251711/55350481-727bc200-5479-11e9-8070-c3d68bf95f40.png)

Once we push the changes here, I'll write up cards for all Beacon clients to pull in the latest versions.