### PR TITLE
Fix for bordered tables on iOS

### DIFF
--- a/src/scss/components/ios/_article.scss
+++ b/src/scss/components/ios/_article.scss
@@ -5,8 +5,8 @@ html {
 }
 
 #fullArticle {
-  padding: 0 15px;
-  font: -apple-system-subheadline;
+    padding: 0 15px;
+    font: -apple-system-subheadline;
 }
 
 #fullArticle .c-Article__title {
@@ -21,4 +21,8 @@ html {
 
 #fullArticle .u-overflow-x {
     overflow-x: auto;
+}
+
+#fullArticle table.table-bordered { 
+    border-collapse: collapse; 
 }


### PR DESCRIPTION
This adds an iOS-specific change to `table-bordered` that I missed in the original PR(#15) syncing some iOS changes to this repository. The original PR can be found [here](https://github.com/helpscout/doc-article-styles/pull/15).